### PR TITLE
ci: skip lock check on release please

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   pull-requests: read
+  statuses: write
 
 jobs:
   conventional-title:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
         run: uv python install 3.14
 
       - name: Ensure uv lockfile is up-to-date
+        if: github.event_name == 'pull_request' && !startsWith(github.head_ref, 'release-please--')
         run: uv lock --check
 
       - name: Install project dependencies

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,6 +3,7 @@ name: Release Please
 on:
   push:
     branches: [master]
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,6 +8,10 @@ permissions:
   contents: write
   pull-requests: write
 
+env:
+  UV_VERSION: "0.11.6"
+  UV_PYTHON_PREFERENCE: "managed"
+
 jobs:
   release-please:
     name: Release Please
@@ -15,9 +19,52 @@ jobs:
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
+      prs: ${{ steps.release.outputs.prs }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+  refresh-lock:
+    name: Refresh uv.lock on release PR
+    needs: release-please
+    if: ${{ needs.release-please.outputs.prs != '' && needs.release-please.outputs.prs != '[]' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Determine release PR branch
+        id: branch
+        run: |
+          BRANCH=$(echo '${{ needs.release-please.outputs.prs }}' | jq -r '.[0].headBranchName')
+          echo "name=$BRANCH" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout release PR branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.branch.outputs.name }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.14
+
+      - name: Refresh uv.lock
+        run: |
+          uv lock
+          if git diff --quiet uv.lock; then
+            echo "uv.lock already in sync — nothing to commit."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add uv.lock
+          git commit -m "chore: refresh uv.lock for release"
+          git push

--- a/uv.lock
+++ b/uv.lock
@@ -1432,7 +1432,7 @@ wheels = [
 
 [[package]]
 name = "snakemk-util"
-version = "2.0.0"
+version = "2.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "snakemake" },


### PR DESCRIPTION
- **chore: sync uv.lock with version 2.0.1**
- **ci: run uv lock check only on non-release-please PRs**
- **ci(release-please): refresh uv.lock on release PR branches**
- **ci(release-please): allow manual workflow_dispatch trigger**
