### PR TITLE
ci: drop redundant lock-check skip for release-please PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,6 @@ jobs:
         run: uv python install 3.14
 
       - name: Ensure uv lockfile is up-to-date
-        if: github.event_name == 'pull_request' && !startsWith(github.head_ref, 'release-please--')
         run: uv lock --check
 
       - name: Install project dependencies


### PR DESCRIPTION
The refresh-lock job in release-please.yml now keeps uv.lock in sync
on the release PR branch, so by the time master sees the merged PR
the lockfile already matches pyproject.toml. The conditional skip
became dead code; restore the unconditional `uv lock --check`.
