### PR TITLE
chore(build): migrate build backend from setuptools to hatchling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["setuptools>=42", "wheel"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
 [project]
 name = "snakemk_util"
@@ -38,7 +38,7 @@ lint = [
     "mypy",
 ]
 
-[tool.setuptools]
+[tool.hatch.build.targets.wheel]
 packages = ["snakemk_util"]
 
 [tool.ruff]


### PR DESCRIPTION
setuptools + the explicit `[tool.setuptools] packages = [...]` block
was the only piece of tooling not aligned with the rest of the
uv-based workflow. Hatchling is a small, pure-python backend with no
configuration scripts, and `uv build` produces an identical wheel
layout.

- `[build-system]` now requires `hatchling` and uses
  `hatchling.build` as the backend.
- `[tool.setuptools]` replaced with the equivalent
  `[tool.hatch.build.targets.wheel]` block listing the package.
- `uv.lock` is unaffected (hatchling is a build dep, not a runtime
  dep) and `uv build` was verified to produce the expected sdist +
  wheel.

