### PR TITLE
feat(cli)!: take --wildcards as repeated key=value tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,8 @@ if (! exists("snakemake")) {
     snakefile = "Snakefile"
     rule = "create_prediction_target"
     python = "/opt/anaconda/envs/snakemake/bin/python"
-    wildcards = paste(
-        # 'comparison=all',
-        sep=','
+    wildcards = c(
+        # "comparison=all",
     )
 
     cmd=c(
@@ -72,9 +71,9 @@ if (! exists("snakemake")) {
         "--rule", rule,
         "--snakefile", normalizePath(snakefile),
         "--root_dir", dirname(normalizePath(snakefile)),
-        "--wildcards", paste0('"', wildcards, '"'),
         "--gen-preamble", "RScript",
-        "--create_dirs"
+        "--create_dirs",
+        if (length(wildcards) > 0) c("--wildcards", wildcards) else NULL
     )
     eval(parse(text=system2(python, cmd, stdout=TRUE, stderr="")))
 }
@@ -85,7 +84,7 @@ if (! exists("snakemake")) {
 
 ```bash
 # snakemk_util --help
-usage: snakemk_util [-h] --rule RULE_NAME [--gen-preamble FLAVOR] [--snakefile SNAKEFILE] [--root_dir ROOT_DIR] [--wildcards WILDCARDS] [--create_dirs]
+usage: snakemk_util [-h] --rule RULE_NAME [--gen-preamble FLAVOR] [--snakefile SNAKEFILE] [--root_dir ROOT_DIR] [--wildcards [KEY=VALUE ...]] [--create_dirs]
 
 Utility to sow Snakemake rule contents and creating script preambles without actually running Snakemake.
 
@@ -97,8 +96,8 @@ optional arguments:
   --snakefile SNAKEFILE
                         path to the Snakefile
   --root_dir ROOT_DIR   Root directory from where you would run the `snakemake` command. By default, this is the current working directory.
-  --wildcards WILDCARDS
-                        Comma-separated key-value list of wildcards which should be used to format the rule output. Example: 'wildcard0=x,wildcard1=y
+  --wildcards [KEY=VALUE ...]
+                        Wildcards used to format the rule output, given as space-separated 'key=value' tokens. Example: --wildcards wildcard0=x wildcard1=y
   --create_dirs         Create the output directories for the rule
 ```
 

--- a/snakemk_util/main.py
+++ b/snakemk_util/main.py
@@ -54,12 +54,14 @@ def main():
     )
     parser.add_argument(
         "--wildcards",
-        action="store",
+        nargs="*",
         dest="wildcards",
-        default="",
+        default=[],
+        metavar="KEY=VALUE",
         help=(
-            "Comma-separated key-value list of wildcards which should be used "
-            "to format the rule output. Example: 'wildcard0=x,wildcard1=y'"
+            "Wildcards used to format the rule output, given as "
+            "space-separated 'key=value' tokens. "
+            "Example: --wildcards wildcard0=x wildcard1=y"
         ),
     )
     parser.add_argument(
@@ -76,22 +78,19 @@ def main():
     from snakemk_util.rule_args import load_rule_args, pretty_print_snakemake
 
     wildcards: dict[str, str] = {}
-    if args.wildcards:
-        for entry in args.wildcards.split(","):
-            if not entry:
-                continue
-            try:
-                key, value = parse_key_value_arg(
-                    entry,
-                    errmsg="Wildcards must be specified as 'key=value' pairs",
-                )
-            except ValueError as exc:
-                parser.error(str(exc))
-            if not _VALID_WILDCARD_NAME.match(key):
-                parser.error(f"Invalid wildcard name {key!r}: must be a valid identifier")
-            if key in wildcards:
-                parser.error(f"Duplicate wildcard key {key!r}")
-            wildcards[key] = value
+    for entry in args.wildcards:
+        try:
+            key, value = parse_key_value_arg(
+                entry,
+                errmsg="Wildcards must be specified as 'key=value' pairs",
+            )
+        except ValueError as exc:
+            parser.error(str(exc))
+        if not _VALID_WILDCARD_NAME.match(key):
+            parser.error(f"Invalid wildcard name {key!r}: must be a valid identifier")
+        if key in wildcards:
+            parser.error(f"Duplicate wildcard key {key!r}")
+        wildcards[key] = value
 
     with redirect_stdout(sys.stderr):
         snakemake_obj = load_rule_args(


### PR DESCRIPTION
Switch `--wildcards` from a single comma-separated string to
`nargs="*"` repeated `KEY=VALUE` tokens, matching the idiom used by
snakemake's own `--config`. Parsing reuses
`snakemake.common.parse_key_value_arg` and validates each key as a
Python identifier.

Side benefits:
- Wildcard values may now contain commas, since values are no longer
  split on `,`.
- Quote-stripping on values is delegated to the upstream helper, so
  shell-quoted inputs round-trip cleanly.
- Help text now renders as `--wildcards [KEY=VALUE ...]`.

The R preamble in the README is updated to emit one element per
pair via `c(...)`, since the previous `paste(..., sep=',')` form no
longer composes a valid argument.

BREAKING CHANGE: `--wildcards` no longer accepts a single
comma-separated string. Callers must pass each pair as its own
argv token, e.g. `--wildcards k1=v1 k2=v2` instead of
`--wildcards "k1=v1,k2=v2"`. A legacy comma-separated string is now
silently interpreted as a single value containing commas, since the
new contract allows commas in values.
