### PR TITLE
ci(snakemake-compat): switch from 6-hourly to daily schedule

### DIFF
--- a/.github/workflows/snakemake-compat.yml
+++ b/.github/workflows/snakemake-compat.yml
@@ -8,14 +8,14 @@ name: Snakemake compatibility
 # not tested before.
 #
 # Trigger paths:
-#   - schedule: backstop poll every 6h
+#   - schedule: backstop daily poll
 #   - workflow_dispatch: manual run
 #   - repository_dispatch (snakemake-release): external bot can ping us
 #     directly so we don't have to wait for the next cron tick
 
 on:
   schedule:
-    - cron: "17 */6 * * *"
+    - cron: "17 6 * * *"
   workflow_dispatch:
   repository_dispatch:
     types: [snakemake-release]


### PR DESCRIPTION
Hourly-class polling is overkill for a backstop that exists to catch
upstream snakemake releases between manual `uv lock` refreshes; one
run per day at 06:17 UTC is enough and keeps Actions usage modest.
External callers can still force a run via `workflow_dispatch` or the
`repository_dispatch` (snakemake-release) trigger when they want to
test a specific upstream tag without waiting for the next tick.
