### PR TITLE
ci: squash release-please PRs and auto-publish to PyPI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,9 +2,17 @@ name: Publish to PyPI
 
 on:
   workflow_dispatch:
-  push:
-    tags:
-      - "v[0-9]+.[0-9]+.[0-9]+*"
+    inputs:
+      ref:
+        description: "Git ref to build and publish"
+        type: string
+        required: false
+  workflow_call:
+    inputs:
+      ref:
+        description: "Git ref to build and publish"
+        type: string
+        required: true
 
 env:
   UV_VERSION: "0.11.6"
@@ -24,7 +32,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -69,3 +69,15 @@ jobs:
           git add uv.lock
           git commit -m "chore: refresh uv.lock for release"
           git push
+
+  publish:
+    name: Publish to PyPI
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created }}
+    permissions:
+      id-token: write
+      contents: read
+    uses: ./.github/workflows/publish.yml
+    with:
+      ref: ${{ needs.release-please.outputs.tag_name }}
+    secrets: inherit

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,4 +1,5 @@
 {
+  "merge-type": "squash",
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "packages": {
     ".": {


### PR DESCRIPTION
- release-please-config.json: set merge-type to squash
- publish.yml: convert push:tags trigger to workflow_call (with optional
  workflow_dispatch ref input) so release-please can chain it
- release-please.yml: add publish job that calls publish.yml when
  release_created is true. GITHUB_TOKEN-pushed tags do not trigger
  downstream workflows, so chaining is required.
