### PR TITLE
ci: add aggregator checks and wire release publish

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -39,3 +39,20 @@ jobs:
             Subject must start with lowercase letter and not end with a period.
             Got: "{subject}"
           wip: true
+
+  # Aggregator job: a single, stable check-run name to use as the required
+  # status check in branch protection, independent of the underlying job name.
+  pr-title-lint:
+    name: PR Title Lint
+    needs: [conventional-title]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Verify PR title lint did not fail
+        run: |
+          # Fail only on failure/cancelled; a skipped run is allowed.
+          result="${{ needs.conventional-title.result }}"
+          if [ "$result" = "failure" ] || [ "$result" = "cancelled" ]; then
+            echo "PR title lint did not pass: $result"
+            exit 1
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main, master]
   pull_request:
-    branches: [main, master]
   workflow_dispatch:
 
 env:
@@ -69,3 +68,22 @@ jobs:
 
       - name: Run tests
         run: uv run tox -e py${{ matrix.python-version }}
+
+  # Aggregator job: a single, stable check-run name to use as the required
+  # status check in branch protection. Stays valid even if the matrix or the
+  # individual job names change.
+  ci:
+    name: CI
+    needs: [quality-checks, test]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Verify no upstream job failed
+        run: |
+          # Fail only on failure/cancelled. A skipped job is allowed
+          for result in "${{ needs.quality-checks.result }}" "${{ needs.test.result }}"; do
+            if [ "$result" = "failure" ] || [ "$result" = "cancelled" ]; then
+              echo "An upstream job did not pass: quality-checks=${{ needs.quality-checks.result }} test=${{ needs.test.result }}"
+              exit 1
+            fi
+          done

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,9 +2,17 @@ name: Publish to PyPI
 
 on:
   workflow_dispatch:
-  push:
-    tags:
-      - "v[0-9]+.[0-9]+.[0-9]+*"
+    inputs:
+      ref:
+        description: "Git ref to build and publish"
+        type: string
+        required: false
+  workflow_call:
+    inputs:
+      ref:
+        description: "Git ref to build and publish"
+        type: string
+        required: true
 
 env:
   UV_VERSION: "0.11.6"
@@ -24,7 +32,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -69,3 +69,15 @@ jobs:
           git add uv.lock
           git commit -m "chore: refresh uv.lock for release"
           git push
+
+  publish:
+    name: Publish to PyPI
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created }}
+    permissions:
+      id-token: write
+      contents: read
+    uses: ./.github/workflows/publish.yml
+    with:
+      ref: ${{ needs.release-please.outputs.tag_name }}
+    secrets: inherit

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,7 +2,7 @@ name: Release Please
 
 on:
   push:
-    branches: [master]
+    branches: [main, master]
   workflow_dispatch:
 
 permissions:
@@ -69,3 +69,15 @@ jobs:
           git add uv.lock
           git commit -m "chore: refresh uv.lock for release"
           git push
+
+  publish:
+    name: Publish to PyPI
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created }}
+    permissions:
+      id-token: write
+      contents: read
+    uses: ./.github/workflows/publish.yml
+    with:
+      ref: ${{ needs.release-please.outputs.tag_name }}
+    secrets: inherit

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,4 +1,5 @@
 {
+  "merge-type": "squash",
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "packages": {
     ".": {


### PR DESCRIPTION
Add stable aggregator jobs (CI, PR Title Lint) for branch protection
required status checks, independent of matrix/job name changes. Run ci
on all PRs. Make publish.yml callable via workflow_call/dispatch with a
ref input, and trigger it from release-please on release creation.
